### PR TITLE
Fix missing email address on New User

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>nodetest2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mongodb": "^2.2.5",
     "monk": "^3.1.1",
     "morgan": "~1.6.1",
-    "newrelic": "1.29.0",
+    "newrelic": "1.31.0",
     "pm2": "^1.1.3",
     "request": "^2.72.0",
     "serve-favicon": "~2.3.0"

--- a/routes/api.js
+++ b/routes/api.js
@@ -45,7 +45,7 @@ router.post('/user', function(req, res) {
     'fname': req.body.fname,
     'lname': req.body.lname,
     'username': req.body.username,
-    'email': req.body.useremail,
+    'useremail': req.body.useremail,
     'addstreet': req.body.addstreet,
     'addcity': req.body.addcity,
     'addstate': req.body.addstate,

--- a/routes/user.js
+++ b/routes/user.js
@@ -71,7 +71,7 @@ router.post('/add', function(req, res) {
         'fname': req.body.fname,
         'lname': req.body.lname,
         'username': req.body.username,
-        'email': req.body.useremail,
+        'useremail': req.body.useremail,
         'addstreet': req.body.addstreet,
         'addcity': req.body.addcity,
         'addstate': req.body.addstate,

--- a/views/userprofile.jade
+++ b/views/userprofile.jade
@@ -16,7 +16,7 @@ block content
           td= user.username
         tr
           th User Email
-          td= user.email
+          td= user.useremail
         tr
           th Street Address
           td= user.addstreet


### PR DESCRIPTION
Fix that New User does not correctly add the user email. And upgrade the New Relic Agent to 1.31.0.
